### PR TITLE
Fix system status logic

### DIFF
--- a/stat_mod_refactored.f90
+++ b/stat_mod_refactored.f90
@@ -171,17 +171,7 @@ program stat_mod
             if(c(k).and.cp) then
                 ch=.true.
             else
-                fail_set=.false.
-                do j=1,kcm
-                    fail_set=.true.
-                    do i=1,m
-                        if(md(j,i) .and. c(i)) then
-                            fail_set=.false.
-                            exit
-                        end if
-                    end do
-                    if(fail_set) exit
-                end do
+                ch=.false.
                 w=0.0
                 if(otv) then
                     do i=1,ki
@@ -192,7 +182,8 @@ program stat_mod
                         if(c(i)) w=w+mg(i)
                     end do
                 end if
-                ch = .not.fail_set .and. w >= wd
+                ch = .true.
+                if(w < wd) ch = .false.
             end if
 
             if(.not.cp .and. ch) then


### PR DESCRIPTION
## Summary
- fix `stat_mod_refactored.f90` logic for determining system status

## Testing
- `gfortran stat_mod_refactored.f90 -o stat_mod_refactored`
- `./stat_mod_refactored < sample_input.txt > final_ref.txt && tail -n 20 final_ref.txt`

------
https://chatgpt.com/codex/tasks/task_e_6859382777348333b7ff2153678a02fb